### PR TITLE
Fix: automatic pip installs do not work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,73 +69,73 @@ jobs:
         name: linux-build
         path: linux-build/libbasic_math_operations-linux.zip
 
-  make-windows:
-    name: Make libbasic_math_operations-windows.a
-    runs-on: windows-latest
-    permissions:
-      actions: write
-      contents: write
-      security-events: write
+  # make-windows:
+  #   name: Make libbasic_math_operations-windows.a
+  #   runs-on: windows-latest
+  #   permissions:
+  #     actions: write
+  #     contents: write
+  #     security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'cpp' ]
-    steps:
-    - name: Set up NASM
-      uses: ilammy/setup-nasm@v1.3.0
-    - name: Set up MinGW
-      uses: egor-tensin/setup-mingw@v2
-      with:
-        platform: x64
-    - name: Checkout repo.
-      uses: actions/checkout@v2
-      with:
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-    - run: |
-        cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G "MinGW Makefiles"
-        cmake --build build --config Release --target all -j 10 --
-        cd  "build/src/library"
-        ren libbasic_math_operations.a libbasic_math_operations-windows.a
-    - uses: actions/upload-artifact@v3
-      with:
-        name: windows-build
-        path: build/src/library/libbasic_math_operations-windows.a
-  make-wheel-windows:
-    needs:
-      - make-windows
-    runs-on: windows-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: dist/artifacts
-      - name: Move version info
-        run: |
-          move dist/artifacts/version-info/version.txt version.txt
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.8.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: dist/artifacts
-      - name: Build wheel
-        run: |
-          python setup.py bdist_wheel
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: windows-whl
-          path: dist/*.whl
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       language: [ 'cpp' ]
+  #   steps:
+  #   - name: Set up NASM
+  #     uses: ilammy/setup-nasm@v1.3.0
+  #   - name: Set up MinGW
+  #     uses: egor-tensin/setup-mingw@v2
+  #     with:
+  #       platform: x64
+  #   - name: Checkout repo.
+  #     uses: actions/checkout@v2
+  #     with:
+  #       persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+  #       fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+  #   - run: |
+  #       cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G "MinGW Makefiles"
+  #       cmake --build build --config Release --target all -j 10 --
+  #       cd  "build/src/library"
+  #       ren libbasic_math_operations.a libbasic_math_operations-windows.a
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: windows-build
+  #       path: build/src/library/libbasic_math_operations-windows.a
+  # make-wheel-windows:
+  #   needs:
+  #     - make-windows
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v3
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: dist/artifacts
+  #     - name: Move version info
+  #       run: |
+  #         move dist/artifacts/version-info/version.txt version.txt
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: '3.8.x'
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install wheel
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: dist/artifacts
+  #     - name: Build wheel
+  #       run: |
+  #         python setup.py bdist_wheel
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: windows-whl
+  #         path: dist/*.whl
   make-wheel-linux:
     needs:
       - make-linux
@@ -181,8 +181,8 @@ jobs:
   release:
     needs:
       - make-linux
-      - make-windows
-      - make-wheel-windows
+      # - make-windows
+      # - make-wheel-windows
       - make-wheel-linux
     runs-on: ubuntu-latest
     steps:
@@ -218,21 +218,21 @@ jobs:
           asset_path: dist/artifacts/linux-build/libbasic_math_operations-linux.zip
           asset_name: libbasic_math_operations-linux.zip
           asset_content_type: application/zip
-      - name: Upload asset for Windows.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/windows-build/libbasic_math_operations-windows.a
-          asset_name: libbasic_math_operations-windows.a
-          asset_content_type: application/octet-stream
+      # - name: Upload asset for Windows.
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: dist/artifacts/windows-build/libbasic_math_operations-windows.a
+      #     asset_name: libbasic_math_operations-windows.a
+      #     asset_content_type: application/octet-stream
       - name: Get Linux and Windows wheel name
         run: |
           cd dist/artifacts/linux-whl/
           echo "LINUX_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
-          cd ../windows-whl/
-          echo "WIN_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
+      # cd ../windows-whl/
+      # echo "WIN_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
           cd ../..
       - name: Upload wheel for Linux.
         uses: actions/upload-release-asset@v1
@@ -243,18 +243,18 @@ jobs:
           asset_path: dist/artifacts/linux-whl/${{ env.LINUX_WHEEL }}
           asset_name: ${{ env.LINUX_WHEEL }}
           asset_content_type: application/octet-stream
-      - name: Upload wheel for Windows.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/windows-whl/${{ env.WIN_WHEEL }}
-          asset_name: ${{ env.WIN_WHEEL }}
-          asset_content_type: application/octet-stream
+      # - name: Upload wheel for Windows.
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: dist/artifacts/windows-whl/${{ env.WIN_WHEEL }}
+      #     asset_name: ${{ env.WIN_WHEEL }}
+      #     asset_content_type: application/octet-stream
   pypi-upload:
     needs:
-      - make-wheel-windows
+      # - make-wheel-windows
       - make-wheel-linux
     runs-on: ubuntu-latest
     steps:
@@ -285,7 +285,7 @@ jobs:
           python -m pip install twine
           python setup.py sdist --formats=gztar
           mkdir -p build/dist/ && mv dist/artifacts build/dist
-          mv build/dist/artifacts/windows-whl/* dist/
+      # mv build/dist/artifacts/windows-whl/* dist/
           mv build/dist/artifacts/linux-whl/* dist/
           echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Run Twine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: "Make libbasic_math_operations."
+name: "Make the library, upload to PyPi, and create a release."
 
 on:
   push:
-    branches: [ main, 14-automatic-pip-installs-do-not-work ]
+    branches: [ main ]
   schedule:
     - cron: '18 13 * * 6'
 
@@ -68,6 +68,73 @@ jobs:
       with:
         name: linux-build
         path: linux-build/libbasic_math_operations-linux.zip
+ make-windows:
+    name: Make libbasic_math_operations-windows.a
+    runs-on: windows-latest
+    permissions:
+      actions: write
+      contents: write
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+    steps:
+    - name: Set up NASM
+      uses: ilammy/setup-nasm@v1.3.0
+    - name: Set up MinGW
+      uses: egor-tensin/setup-mingw@v2
+      with:
+        platform: x64
+    - name: Checkout repo.
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+    - run: |
+        cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G "MinGW Makefiles"
+        cmake --build build --config Release --target all -j 10 --
+        cd  "build/src/library"
+        ren libbasic_math_operations.a libbasic_math_operations-windows.a
+    - uses: actions/upload-artifact@v3
+      with:
+        name: windows-build
+        path: build/src/library/libbasic_math_operations-windows.a
+  make-wheel-windows:
+    needs:
+      - make-windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: dist/artifacts
+      - name: Move version info
+        run: |
+          cp dist/artifacts/version-info/version.txt version.txt
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: dist/artifacts
+      - name: Build wheel
+        run: |
+          python setup.py bdist_wheel
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-whl
+          path: dist/*.whl
   make-wheel-linux:
     needs:
       - make-linux
@@ -113,7 +180,9 @@ jobs:
   release:
     needs:
       - make-linux
+      - make-windows
       - make-wheel-linux
+      - make-wheel-windows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -148,10 +217,21 @@ jobs:
           asset_path: dist/artifacts/linux-build/libbasic_math_operations-linux.zip
           asset_name: libbasic_math_operations-linux.zip
           asset_content_type: application/zip
+      - name: Upload asset for Windows.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/windows-build/libbasic_math_operations-windows.a
+          asset_name: libbasic_math_operations-windows.a
+          asset_content_type: application/octet-stream
       - name: Get Linux and Windows wheel name
         run: |
           cd dist/artifacts/linux-whl/
           echo "LINUX_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
+          cd ../windows-whl/
+          echo "WIN_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
           cd ../..
       - name: Upload wheel for Linux.
         uses: actions/upload-release-asset@v1
@@ -161,6 +241,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: dist/artifacts/linux-whl/${{ env.LINUX_WHEEL }}
           asset_name: ${{ env.LINUX_WHEEL }}
+          asset_content_type: application/octet-stream
+      - name: Upload wheel for Windows.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/windows-whl/${{ env.WIN_WHEEL }}
+          asset_name: ${{ env.WIN_WHEEL }}
           asset_content_type: application/octet-stream
   pypi-upload:
     needs:
@@ -194,6 +283,7 @@ jobs:
           python -m pip install twine
           python setup.py sdist --formats=gztar
           mkdir -p build/dist/ && mv dist/artifacts build/dist
+          mv build/dist/artifacts/windows-whl/* dist/
           mv build/dist/artifacts/linux-whl/* dist/
           echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Run Twine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8.x'
+          python-version: '3.10.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8.x'
+          python-version: '3.10.x'
       - name: Git Version
         id: version
         uses: codacy/git-version@2.7.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Make libbasic_math_operations."
 
 on:
   push:
-    branches: [ main, patch-3 ]
+    branches: [ main, 14-automatic-pip-installs-do-not-work ]
   schedule:
     - cron: '18 13 * * 6'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,74 +68,6 @@ jobs:
       with:
         name: linux-build
         path: linux-build/libbasic_math_operations-linux.zip
-
-  # make-windows:
-  #   name: Make libbasic_math_operations-windows.a
-  #   runs-on: windows-latest
-  #   permissions:
-  #     actions: write
-  #     contents: write
-  #     security-events: write
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       language: [ 'cpp' ]
-  #   steps:
-  #   - name: Set up NASM
-  #     uses: ilammy/setup-nasm@v1.3.0
-  #   - name: Set up MinGW
-  #     uses: egor-tensin/setup-mingw@v2
-  #     with:
-  #       platform: x64
-  #   - name: Checkout repo.
-  #     uses: actions/checkout@v2
-  #     with:
-  #       persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
-  #       fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-  #   - run: |
-  #       cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G "MinGW Makefiles"
-  #       cmake --build build --config Release --target all -j 10 --
-  #       cd  "build/src/library"
-  #       ren libbasic_math_operations.a libbasic_math_operations-windows.a
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: windows-build
-  #       path: build/src/library/libbasic_math_operations-windows.a
-  # make-wheel-windows:
-  #   needs:
-  #     - make-windows
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v3
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: dist/artifacts
-  #     - name: Move version info
-  #       run: |
-  #         move dist/artifacts/version-info/version.txt version.txt
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: '3.8.x'
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install wheel
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: dist/artifacts
-  #     - name: Build wheel
-  #       run: |
-  #         python setup.py bdist_wheel
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: windows-whl
-  #         path: dist/*.whl
   make-wheel-linux:
     needs:
       - make-linux
@@ -181,8 +113,6 @@ jobs:
   release:
     needs:
       - make-linux
-      # - make-windows
-      # - make-wheel-windows
       - make-wheel-linux
     runs-on: ubuntu-latest
     steps:
@@ -218,21 +148,10 @@ jobs:
           asset_path: dist/artifacts/linux-build/libbasic_math_operations-linux.zip
           asset_name: libbasic_math_operations-linux.zip
           asset_content_type: application/zip
-      # - name: Upload asset for Windows.
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: dist/artifacts/windows-build/libbasic_math_operations-windows.a
-      #     asset_name: libbasic_math_operations-windows.a
-      #     asset_content_type: application/octet-stream
       - name: Get Linux and Windows wheel name
         run: |
           cd dist/artifacts/linux-whl/
           echo "LINUX_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
-      # cd ../windows-whl/
-      # echo "WIN_WHEEL=$(ls *.whl)" >> $GITHUB_ENV
           cd ../..
       - name: Upload wheel for Linux.
         uses: actions/upload-release-asset@v1
@@ -243,18 +162,8 @@ jobs:
           asset_path: dist/artifacts/linux-whl/${{ env.LINUX_WHEEL }}
           asset_name: ${{ env.LINUX_WHEEL }}
           asset_content_type: application/octet-stream
-      # - name: Upload wheel for Windows.
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: dist/artifacts/windows-whl/${{ env.WIN_WHEEL }}
-      #     asset_name: ${{ env.WIN_WHEEL }}
-      #     asset_content_type: application/octet-stream
   pypi-upload:
     needs:
-      # - make-wheel-windows
       - make-wheel-linux
     runs-on: ubuntu-latest
     steps:
@@ -285,7 +194,6 @@ jobs:
           python -m pip install twine
           python setup.py sdist --formats=gztar
           mkdir -p build/dist/ && mv dist/artifacts build/dist
-      # mv build/dist/artifacts/windows-whl/* dist/
           mv build/dist/artifacts/linux-whl/* dist/
           echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Run Twine

--- a/README.md
+++ b/README.md
@@ -45,15 +45,7 @@ Downloading and using this library is as simple as including the header file (`b
 
 # Installation
 Note: This section only applies to Python.
-To install the module `basic_math_operations`, clone the repository, and build the library with CMake. Next, run the `setup.py` file. Here are all the commands you will need to run (for Windows, just don't sudo the last command).
-
-```shell
-cmake -S . -B build
-cd build
-make
-cd ../
-sudo python3 setup.py install
-```
+To install the module `basic_math_operations`, you can use pip (for Python >= 3.10). You can also manually install it from [here](https://pypi.org/project/basic-math-operations/) if that doesn't work for you.
 
 And you're done! Now you'll be able to import the library into your Python programs using this line: `import basic_math_operations`.
 
@@ -70,11 +62,12 @@ main.c:
 int main() {
   char* a = (char *)calloc(1024, 1);
   char* b = (char *)calloc(1024, 1);
-  char* res = (char *)calloc(1100, 1);
   printf("Enter the first number: ");
   scanf("%1023s", a);
   printf("Enter the second number: ");
   scanf("%1023s", b);
+
+  char* res = (char *)calloc(strlen(a) + strlen(b) + 43, 1);
 
   divide(a, b, res, 40);
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ from zipfile import ZipFile
 module_name = 'basic_math_operations'
 version = '1.0.0'
 
+# Print current directory
+print("Current directory: " + os.getcwd())
+
 if (os.path.exists('dist/artifacts/linux-build/libbasic_math_operations-linux.zip') and os.name != 'nt'):
     with zipfile.ZipFile('dist/artifacts/linux-build/libbasic_math_operations-linux.zip', 'r') as zfile:
         zfile.extract('libbasic_math_operations.a')
@@ -19,9 +22,8 @@ if (os.path.exists('dist/artifacts/linux-build/libbasic_math_operations-linux.zi
 if (os.path.exists('dist/artifacts/windows-build/libbasic_math_operations-windows.a') and os.name == 'nt'):
     shutil.copy("dist/artifacts/windows-build/libbasic_math_operations-windows.a",
                 "src/python-module/libbasic_math_operations.a")
-if (os.path.exists('dist/artifacts/version-info/version.txt')):
-    shutil.copy("dist/artifacts/version-info/version.txt",
-                "src/python-module/version.txt")
+shutil.copy("dist/artifacts/version-info/version.txt",
+        "src/python-module/version.txt")
 
 with open('version.txt' if os.path.exists('version.txt') else 'src/python-module/version.txt', 'r') as f:
     version = f.read()

--- a/src/python-module/fix-version.cpp
+++ b/src/python-module/fix-version.cpp
@@ -9,6 +9,8 @@ int main(int argc, char **argv) {
   std::string version;
   std::getline(in, version);
 
+  bool main = version.find("-main") != std::string::npos;
+
   // 0.0.1-main.116.2397cac
   // Find first occurence of '-'
   version = version.substr(version.find('-') + 1, version.length());
@@ -18,7 +20,11 @@ int main(int argc, char **argv) {
   // 116.2397cac
   std::string patch = version.substr(0, version.find('.'));
 
-  std::string new_version = "0.0." + patch;
+  std::string new_version;
+  if (main) {
+    new_version += "1.0." + patch;
+  } else
+    new_version += "0.0." + patch;
 
   std::cout << new_version << std::endl;
 


### PR DESCRIPTION
# Fixes #14 

- Added files to package data.
- Made GH actions build using python 3.10.x instead of 3.8.x
- Modified `fix-version.cpp` to prioritize the main branch.